### PR TITLE
Use only Neon PostgreSQL and remove fallback to SQLite

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd src && python manage.py collectstatic --noinput && python manage.py check --database default && gunicorn recipe_app.wsgi:application --worker-class=gevent --workers=1 --threads=2 --timeout=30 --max-requests=20 --max-requests-jitter=5
+web: cd src && python manage.py collectstatic --noinput && gunicorn recipe_app.wsgi:application --worker-class=gevent --workers=1 --threads=4 --timeout=40 --max-requests=10 --max-requests-jitter=2 --keep-alive=2 --graceful-timeout=10

--- a/src/recipe_app/db_utils.py
+++ b/src/recipe_app/db_utils.py
@@ -1,0 +1,57 @@
+# src/recipe_app/db_utils.py
+
+import time
+import random
+import logging
+import psycopg2
+from psycopg2 import OperationalError, InterfaceError
+
+logger = logging.getLogger(__name__)
+
+def connect_with_retry(db_url, max_retries=5, backoff_factor=0.5):
+    """
+    Attempt to connect to PostgreSQL with exponential backoff retry logic.
+    
+    Args:
+        db_url (str): Database connection URL
+        max_retries (int): Maximum number of retry attempts
+        backoff_factor (float): Factor to determine backoff time between retries
+        
+    Returns:
+        connection: PostgreSQL connection object
+        
+    Raises:
+        Exception: If connection fails after all retries
+    """
+    retries = 0
+    last_exception = None
+    
+    while retries < max_retries:
+        try:
+            # Attempt connection
+            conn = psycopg2.connect(db_url)
+            
+            # Configure connection settings
+            conn.set_session(autocommit=True)
+            
+            logger.info("Successfully connected to Neon PostgreSQL database")
+            return conn
+            
+        except (OperationalError, InterfaceError) as e:
+            last_exception = e
+            retries += 1
+            
+            # Calculate backoff time with jitter
+            backoff_time = backoff_factor * (2 ** retries) + random.uniform(0, 0.5)
+            
+            if "rate limit" in str(e).lower():
+                logger.warning(f"Hit Neon rate limit, retrying in {backoff_time:.2f} seconds (attempt {retries}/{max_retries})")
+            else:
+                logger.warning(f"Database connection error: {str(e)}. Retrying in {backoff_time:.2f} seconds (attempt {retries}/{max_retries})")
+                
+            # Sleep with backoff
+            time.sleep(backoff_time)
+    
+    # If we exit the loop, we've failed to connect
+    logger.error(f"Failed to connect to Neon PostgreSQL after {max_retries} attempts. Last error: {str(last_exception)}")
+    raise last_exception


### PR DESCRIPTION
This PR makes several important changes to ensure our app works reliably with Neon PostgreSQL and eliminates the fallback to SQLite that was causing data duplication issues.

## Changes:

1. **Database Configuration**:
   - Removed SQLite fallback logic
   - Made DATABASE_URL required
   - Optimized PostgreSQL connection settings for Neon's serverless architecture
   - Set connection timeout parameters to avoid rate limits

2. **Connection Management**:
   - Added db_utils.py with connection retry logic and exponential backoff
   - Improved error handling for Neon-specific rate limit errors
   - Added proper logging for database connection issues

3. **Performance Optimization**:
   - Updated Procfile to use better gunicorn settings for minimizing connections
   - Increased timeout values to accommodate potential cold-starts
   - Set shorter keep-alive and reduced max requests per worker

These changes should eliminate the SQLite fallback issue, ensure the app uses only Neon PostgreSQL, and help manage the connection limits and rate limits on Neon's free tier.

## Deployment Instructions:

After merging, deploy to Heroku with:
```bash
git push heroku main
```

No need to run migrations since the database structure remains the same.